### PR TITLE
Do not include `_weak_cache` in `Store` pickle state

### DIFF
--- a/static_frame/core/store.py
+++ b/static_frame/core/store.py
@@ -85,6 +85,8 @@ class Store:
             raise StoreFileMutation(f'expected file {self._fp} no longer exists')
 
     def __getstate__(self) -> tp.Tuple[None, tp.Dict[str, tp.Any]]:
+        # https://docs.python.org/3/library/pickle.html#object.__getstate__
+        # staying consistent with __slots__ only objects by using None as first value in tuple
         return (
             None,
             {
@@ -94,7 +96,7 @@ class Store:
             }
         )
 
-    def __setstate__(self, state: tp.Any) -> None:
+    def __setstate__(self, state: tp.Tuple[None, tp.Dict[str, tp.Any]]) -> None:
         for key, value in state[1].items():
             setattr(self, key, value)
         self._weak_cache = WeakValueDictionary()

--- a/static_frame/core/store.py
+++ b/static_frame/core/store.py
@@ -84,6 +84,21 @@ class Store:
             # file existed previously and we got a modification time, but now it does not exist
             raise StoreFileMutation(f'expected file {self._fp} no longer exists')
 
+    def __getstate__(self) -> tp.Tuple[None, tp.Dict[str, tp.Any]]:
+        return (
+            None,
+            {
+                attr: getattr(self, attr)
+                for attr in self.__slots__
+                if attr != '_weak_cache'
+            }
+        )
+
+    def __setstate__(self, state: tp.Any) -> None:
+        for key, value in state[1].items():
+            setattr(self, key, value)
+        self._weak_cache = WeakValueDictionary()
+
     # def __copy__(self) -> 'Store':
     #     '''
     #     Return a new Store instance linked to the same file.

--- a/static_frame/test/unit/test_bus.py
+++ b/static_frame/test/unit/test_bus.py
@@ -2388,7 +2388,7 @@ class TestUnit(TestCase):
             assert not b2._store._weak_cache
 
             f1_r = b2.iloc[0]
-            b2.iloc[1]  # type: ignore
+            b2.iloc[1]
 
             assert f1_r in b2._store._weak_cache.values()
             assert b2.iloc[0] is f1_r

--- a/static_frame/test/unit/test_bus.py
+++ b/static_frame/test/unit/test_bus.py
@@ -2388,7 +2388,9 @@ class TestUnit(TestCase):
             assert not b2._store._weak_cache
 
             f1_r = b2.iloc[0]
-            b2.iloc[1]
+            f2_r = b2.iloc[1]
+
+            assert b2.iloc[1] is f2_r
 
             assert f1_r in b2._store._weak_cache.values()
             assert b2.iloc[0] is f1_r

--- a/static_frame/test/unit/test_bus.py
+++ b/static_frame/test/unit/test_bus.py
@@ -2388,7 +2388,7 @@ class TestUnit(TestCase):
             assert not b2._store._weak_cache
 
             f1_r = b2.iloc[0]
-            b2.iloc[1]
+            b2.iloc[1]  # type: ignore
 
             assert f1_r in b2._store._weak_cache.values()
             assert b2.iloc[0] is f1_r

--- a/static_frame/test/unit/test_bus.py
+++ b/static_frame/test/unit/test_bus.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 import typing as tp
 from datetime import date
 from datetime import datetime
@@ -2372,6 +2373,30 @@ class TestUnit(TestCase):
         self.assertEqual(d,
                 '29a271e0d800ecaa673c7deded9dd7e8166cc746963c1717298e6af9e4189f23')
 
+    #---------------------------------------------------------------------------
+
+    def test_bus_store_pickle_roundtrip(self) -> None:
+        f1 = ff.parse('s(4,2)').rename('f1')
+        f2 = ff.parse('s(2,2)').rename('f2')
+
+        b1 = Bus.from_frames((f1, f2))
+
+        with temp_file('.zip') as fp:
+            b1.to_zip_npz(fp)
+            b2 = Bus.from_zip_npz(fp, max_persist=1)
+
+            assert not b2._store._weak_cache
+
+            f1_r = b2.iloc[0]
+            b2.iloc[1]
+
+            assert f1_r in b2._store._weak_cache.values()
+            assert b2.iloc[0] is f1_r
+
+            b3 = pickle.loads(pickle.dumps(b2))
+
+            assert not b3._store._weak_cache
+            assert b3.iloc[0].equals(f1_r)
 
 
 if __name__ == '__main__':

--- a/static_frame/test/unit/test_store.py
+++ b/static_frame/test/unit/test_store.py
@@ -340,15 +340,14 @@ class TestUnit(TestCase):
     #---------------------------------------------------------------------------
 
     def test_store_pickle_excludes_weak_cache(self) -> None:
-        s = MockStore('/test.tst')
+        s1 = MockStore('/test.tst')
 
-        s._weak_cache["abc"] = Frame()
+        s1._weak_cache["abc"] = Frame()
 
-        s_pickle = pickle.dumps(s)
-        s_unpickled = pickle.loads(s_pickle)
+        s2 = pickle.loads(pickle.dumps(s1))
 
-        assert "abc" not in s_unpickled._weak_cache
-        assert not s_unpickled._weak_cache
+        assert "abc" not in s2._weak_cache
+        assert not s2._weak_cache
 
 
 if __name__ == '__main__':

--- a/static_frame/test/unit/test_store.py
+++ b/static_frame/test/unit/test_store.py
@@ -1,4 +1,6 @@
 from itertools import product
+import pickle
+import typing as tp
 
 import numpy as np
 
@@ -11,6 +13,8 @@ from static_frame.core.store_config import StoreConfigHE
 from static_frame.core.store_config import StoreConfigMap
 from static_frame.test.test_case import TestCase
 
+class MockStore(Store):
+    _EXT = frozenset({".tst"})
 
 class TestUnit(TestCase):
 
@@ -332,6 +336,19 @@ class TestUnit(TestCase):
 
         sc1m = StoreConfigMap.from_initializer(maps)
         self.assertTrue(sc1m.default == StoreConfigMap._DEFAULT)
+
+    #---------------------------------------------------------------------------
+
+    def test_store_pickle_excludes_weak_cache(self) -> None:
+        s = MockStore('/test.tst')
+
+        s._weak_cache["abc"] = Frame()
+
+        s_pickle = pickle.dumps(s)
+        s_unpickled = pickle.loads(s_pickle)
+
+        assert "abc" not in s_unpickled._weak_cache
+        assert not s_unpickled._weak_cache
 
 
 if __name__ == '__main__':

--- a/static_frame/test/unit/test_store.py
+++ b/static_frame/test/unit/test_store.py
@@ -1,5 +1,5 @@
-from itertools import product
 import pickle
+from itertools import product
 
 import numpy as np
 
@@ -11,6 +11,7 @@ from static_frame.core.store_config import StoreConfig
 from static_frame.core.store_config import StoreConfigHE
 from static_frame.core.store_config import StoreConfigMap
 from static_frame.test.test_case import TestCase
+
 
 class MockStore(Store):
     _EXT = frozenset({".tst"})

--- a/static_frame/test/unit/test_store.py
+++ b/static_frame/test/unit/test_store.py
@@ -1,6 +1,5 @@
 from itertools import product
 import pickle
-import typing as tp
 
 import numpy as np
 


### PR DESCRIPTION
Removes `_weak_cache` from `Store` pickle state to allow pickleing and therefore easier use in multi processing.

https://github.com/static-frame/static-frame/issues/743