### PR TITLE
Fix .loc Type Hints for Compound Containers

### DIFF
--- a/static_frame/core/batch.py
+++ b/static_frame/core/batch.py
@@ -17,7 +17,7 @@ from static_frame.core.node_dt import InterfaceBatchDatetime
 from static_frame.core.node_fill_value import InterfaceBatchFillValue
 from static_frame.core.node_re import InterfaceBatchRe
 from static_frame.core.node_selector import InterfaceBatchAsType
-from static_frame.core.node_selector import InterfaceGetItem
+from static_frame.core.node_selector import InterfaceGetItemCompound
 from static_frame.core.node_selector import InterfaceSelectTrio
 from static_frame.core.node_str import InterfaceBatchString
 from static_frame.core.node_transpose import InterfaceBatchTranspose
@@ -718,16 +718,16 @@ class Batch(ContainerOperand, StoreClientMixin):
     # interfaces
 
     @property
-    def loc(self) -> InterfaceGetItem['Batch']:
-        return InterfaceGetItem(self._extract_loc)
+    def loc(self) -> InterfaceGetItemCompound['Batch']:
+        return InterfaceGetItemCompound(self._extract_loc)
 
     @property
-    def iloc(self) -> InterfaceGetItem['Batch']:
-        return InterfaceGetItem(self._extract_iloc)
+    def iloc(self) -> InterfaceGetItemCompound['Batch']:
+        return InterfaceGetItemCompound(self._extract_iloc)
 
     @property
-    def bloc(self) -> InterfaceGetItem['Batch']:
-        return InterfaceGetItem(self._extract_bloc)
+    def bloc(self) -> InterfaceGetItemCompound['Batch']:
+        return InterfaceGetItemCompound(self._extract_bloc)
 
     @property
     def drop(self) -> InterfaceSelectTrio['Batch']:

--- a/static_frame/core/frame.py
+++ b/static_frame/core/frame.py
@@ -96,7 +96,7 @@ from static_frame.core.node_re import InterfaceRe
 from static_frame.core.node_selector import InterfaceAssignQuartet
 from static_frame.core.node_selector import InterfaceAsType
 from static_frame.core.node_selector import InterfaceConsolidate
-from static_frame.core.node_selector import InterfaceGetItem
+from static_frame.core.node_selector import InterfaceGetItemCompound
 from static_frame.core.node_selector import InterfaceSelectTrio
 from static_frame.core.node_str import InterfaceString
 from static_frame.core.node_transpose import InterfaceTranspose
@@ -3443,16 +3443,16 @@ class Frame(ContainerOperand):
     # interfaces
 
     @property
-    def loc(self) -> InterfaceGetItem['Frame']:
-        return InterfaceGetItem(self._extract_loc)
+    def loc(self) -> InterfaceGetItemCompound['Frame']:
+        return InterfaceGetItemCompound(self._extract_loc)
 
     @property
-    def iloc(self) -> InterfaceGetItem['Frame']:
-        return InterfaceGetItem(self._extract_iloc)
+    def iloc(self) -> InterfaceGetItemCompound['Frame']:
+        return InterfaceGetItemCompound(self._extract_iloc)
 
     @property
-    def bloc(self) -> InterfaceGetItem['Frame']:
-        return InterfaceGetItem(self._extract_bloc)
+    def bloc(self) -> InterfaceGetItemCompound['Frame']:
+        return InterfaceGetItemCompound(self._extract_bloc)
 
     @property
     def drop(self) -> InterfaceSelectTrio['Frame']:

--- a/static_frame/core/interface.py
+++ b/static_frame/core/interface.py
@@ -65,6 +65,7 @@ from static_frame.core.node_selector import InterfaceAsType
 from static_frame.core.node_selector import InterfaceBatchAsType
 from static_frame.core.node_selector import InterfaceConsolidate
 from static_frame.core.node_selector import InterfaceGetItem
+from static_frame.core.node_selector import InterfaceGetItemCompound
 from static_frame.core.node_selector import InterfaceSelectDuo
 from static_frame.core.node_selector import InterfaceSelectTrio
 from static_frame.core.node_selector import TContainer
@@ -1190,7 +1191,7 @@ class InterfaceSummary(Features):
                 yield from InterfaceRecord.gen_from_exporter(**kwargs)
             elif name.startswith('iter_'):
                 yield from InterfaceRecord.gen_from_iterator(**kwargs)
-            elif isinstance(obj, InterfaceGetItem) or name == cls.GETITEM:
+            elif isinstance(obj, (InterfaceGetItem, InterfaceGetItemCompound)) or name == cls.GETITEM:
                 yield from InterfaceRecord.gen_from_getitem(**kwargs)
 
             elif obj.__class__ in INTERFACE_ATTRIBUTE_CLS:

--- a/static_frame/core/node_selector.py
+++ b/static_frame/core/node_selector.py
@@ -8,6 +8,7 @@ from static_frame.core.util import NULL_SLICE
 from static_frame.core.util import AnyCallable
 from static_frame.core.util import DtypesSpecifier
 from static_frame.core.util import GetItemKeyType
+from static_frame.core.util import GetItemKeyTypeCompound
 
 # from static_frame.core.util import AnyCallable
 
@@ -62,6 +63,19 @@ class InterfaceGetItem(Interface[TContainer]):
         self._func = func #type: ignore
 
     def __getitem__(self, key: GetItemKeyType) -> TContainer:
+        return self._func(key) #type: ignore
+
+class InterfaceGetItemCompound(Interface[TContainer]):
+
+    __slots__ = ('_func',)
+    INTERFACE = ('__getitem__',)
+
+    _func: tp.Callable[[GetItemKeyTypeCompound], TContainer]
+
+    def __init__(self, func: tp.Callable[[GetItemKeyTypeCompound], TContainer]) -> None:
+        self._func = func #type: ignore
+
+    def __getitem__(self, key: GetItemKeyTypeCompound) -> TContainer:
         return self._func(key) #type: ignore
 
 #-------------------------------------------------------------------------------

--- a/static_frame/core/quilt.py
+++ b/static_frame/core/quilt.py
@@ -31,7 +31,7 @@ from static_frame.core.node_iter import IterNodeAxis
 from static_frame.core.node_iter import IterNodeConstructorAxis
 from static_frame.core.node_iter import IterNodeType
 from static_frame.core.node_iter import IterNodeWindow
-from static_frame.core.node_selector import InterfaceGetItem
+from static_frame.core.node_selector import InterfaceGetItemCompound
 from static_frame.core.series import Series
 from static_frame.core.store import Store
 from static_frame.core.store_client_mixin import StoreClientMixin
@@ -1148,12 +1148,12 @@ class Quilt(ContainerBase, StoreClientMixin):
     # interfaces
 
     @property
-    def loc(self) -> InterfaceGetItem['Frame']:
-        return InterfaceGetItem(self._extract_loc) #type: ignore
+    def loc(self) -> InterfaceGetItemCompound['Frame']:
+        return InterfaceGetItemCompound(self._extract_loc) #type: ignore
 
     @property
-    def iloc(self) -> InterfaceGetItem['Frame']:
-        return InterfaceGetItem(self._extract_iloc) #type: ignore
+    def iloc(self) -> InterfaceGetItemCompound['Frame']:
+        return InterfaceGetItemCompound(self._extract_iloc) #type: ignore
 
     #---------------------------------------------------------------------------
     # iterators


### PR DESCRIPTION
Submitting a tuple to .loc on Compound containers (like Frame) performs a multi-dimensional access. These changes fix the type-hints so that loc/iloc can accept tuples.
```
>>> f
<Frame>
<Index> a       b       c       d       <<U1>
<Index>
0       2       8       4       9
1       3       9       8       2
2       4       10      2       1
<int64> <int64> <int64> <int64> <int64>
>>> f.loc[0, "a"]
2
```