### PR TITLE
Support loading parquet files saved with pyarrow<1.0

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -12,7 +12,7 @@ disable_error_code = misc
 [mypy-hypothesis.strategies]
 implicit_reexport = True
 
-[mypy-IPython,openpyxl,pandas,pyarrow,pytest,setuptools,sphinx.*,sphinx_rtd_theme,scipy.*,tables,xarray,xlsxwriter.*,arraymap,arraykit,frame_fixtures]
+[mypy-IPython,openpyxl,pandas,pyarrow,pyarrow.*,pytest,setuptools,sphinx.*,sphinx_rtd_theme,scipy.*,tables,xarray,xlsxwriter.*,arraymap,arraykit,frame_fixtures]
 ignore_missing_imports = True
 
 [mypy-doc.*]

--- a/static_frame/core/frame.py
+++ b/static_frame/core/frame.py
@@ -27,7 +27,7 @@ from arraykit import resolve_dtype
 from arraykit import resolve_dtype_iter
 from arraykit import split_after_count
 from numpy.ma import MaskedArray
-from pyarrow.lib import ArrowInvalid
+from pyarrow.lib import ArrowInvalid  # pylint: disable=E0611
 
 from static_frame.core.archive_npy import NPYFrameConverter
 from static_frame.core.archive_npy import NPZFrameConverter

--- a/static_frame/core/frame.py
+++ b/static_frame/core/frame.py
@@ -3151,7 +3151,7 @@ class Frame(ContainerOperand):
         except ArrowInvalid:
             # support loading parquet files saved with pyarrow<1.0
             # https://github.com/apache/arrow/issues/32660
-            table = pq.read_table(fp,
+            table = pq.read_table(fp,  # pragma: nocover
                     columns=columns_select,
                     use_pandas_metadata=False,
                     use_legacy_dataset=True,

--- a/static_frame/core/frame.py
+++ b/static_frame/core/frame.py
@@ -3132,7 +3132,7 @@ class Frame(ContainerOperand):
             {name}
             {consolidate_blocks}
         '''
-        import pyarrow.parquet as pq  # type: ignore
+        import pyarrow.parquet as pq
 
         if columns_select and index_depth != 0:
             raise ErrorInitFrame(f'cannot load index_depth {index_depth} when columns_select is specified.')

--- a/static_frame/core/frame.py
+++ b/static_frame/core/frame.py
@@ -3148,10 +3148,10 @@ class Frame(ContainerOperand):
                     columns=columns_select,
                     use_pandas_metadata=False,
                     )
-        except ArrowInvalid:
+        except ArrowInvalid:  # pragma: no cover
             # support loading parquet files saved with pyarrow<1.0
             # https://github.com/apache/arrow/issues/32660
-            table = pq.read_table(fp,  # pragma: nocover
+            table = pq.read_table(fp,  # pragma: no cover
                     columns=columns_select,
                     use_pandas_metadata=False,
                     use_legacy_dataset=True,

--- a/static_frame/core/frame.py
+++ b/static_frame/core/frame.py
@@ -27,7 +27,6 @@ from arraykit import resolve_dtype
 from arraykit import resolve_dtype_iter
 from arraykit import split_after_count
 from numpy.ma import MaskedArray
-from pyarrow.lib import ArrowInvalid  # pylint: disable=E0611
 
 from static_frame.core.archive_npy import NPYFrameConverter
 from static_frame.core.archive_npy import NPZFrameConverter
@@ -3133,6 +3132,7 @@ class Frame(ContainerOperand):
             {consolidate_blocks}
         '''
         import pyarrow.parquet as pq
+        from pyarrow.lib import ArrowInvalid  # pylint: disable=E0611
 
         if columns_select and index_depth != 0:
             raise ErrorInitFrame(f'cannot load index_depth {index_depth} when columns_select is specified.')


### PR DESCRIPTION
pyarrow<1.0 saved parquet files in a format that cannot be loaded by pyarrow>=1.0 unless you add `use_legacy_dataset=True` to the pyarrow.parquet.read_table call. 

This changes adds a fallback to use_legacy_dataset=True if the initial read_table call fails.

Related pyarrow issues:
https://github.com/apache/arrow/issues/32660
https://github.com/apache/arrow/issues/24407