### PR TITLE
sphinxcontrib.napoleon -> sphinx.ext.napoleon

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -104,7 +104,7 @@ extensions = [
         'sphinx.ext.viewcode',
         'sphinx.ext.graphviz',
         'sphinx.ext.inheritance_diagram',
-        'sphinxcontrib.napoleon',
+        'sphinx.ext.napoleon',
         'sphinx_jinja',
         ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,4 +31,3 @@ line-profiler==4.0.3
 sphinx==6.2.1
 sphinx-jinja==2.0.2
 sphinx_rtd_theme==1.2.0
-sphinxcontrib-napoleon==0.7.0


### PR DESCRIPTION
Napoleon is builtin since Sphinx 1.3. The pip dependency no longer supports python 3.11. This change removes the pip dependency in favor of the builtin version of napoleon.