### PR TITLE
Fix Docs Search

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -186,10 +186,7 @@ pygments_style = 'sphinx'
 #     html_theme = 'sphinx_rtd_theme'
 #     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
-import sphinx_rtd_theme
-
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 
 # Theme options are theme-specific and customize the look and feel of a theme


### PR DESCRIPTION
Search was hanging indefinitely because of a sphinx_rtd_theme configuration problem.

Related issue: https://github.com/readthedocs/sphinx_rtd_theme/issues/1452

Example failing:
![image](https://github.com/static-frame/static-frame/assets/113062340/34f3ca02-9050-4a18-aab2-773728188bf3)
