### PR TITLE
Alias ContainerBase at root level

### DIFF
--- a/static_frame/__init__.py
+++ b/static_frame/__init__.py
@@ -11,6 +11,7 @@ from static_frame.core.archive_npy import NPY as NPY
 from static_frame.core.archive_npy import NPZ as NPZ
 from static_frame.core.batch import Batch as Batch
 from static_frame.core.bus import Bus as Bus
+from static_frame.core.container import ContainerBase
 from static_frame.core.display import Display as Display
 from static_frame.core.display import DisplayActive as DisplayActive
 from static_frame.core.display_config import DisplayConfig as DisplayConfig


### PR DESCRIPTION
I think it's useful to export `ContainerBase`, so that users can do high level checks to see if an object is a static_frame container (i.e., `if isinstance(thing, sf.ContainerBase)`). 

Any objections to doing so?