### PR TITLE
Add iter_label interface to IndexBase

### DIFF
--- a/static_frame/core/index_base.py
+++ b/static_frame/core/index_base.py
@@ -17,6 +17,7 @@ from static_frame.core.display_config import DisplayFormats
 from static_frame.core.doc_str import doc_inject
 from static_frame.core.exception import ErrorInitIndex
 from static_frame.core.node_dt import InterfaceDatetime
+from static_frame.core.node_iter import IterNodeDepthLevel
 from static_frame.core.node_re import InterfaceRe
 from static_frame.core.node_str import InterfaceString
 from static_frame.core.style_config import STYLE_CONFIG_DEFAULT
@@ -186,6 +187,10 @@ class IndexBase(ContainerOperandSequence):
         raise NotImplementedError() #pragma: no cover
 
     def __contains__(self, value: TLabel) -> bool:
+        raise NotImplementedError() #pragma: no cover
+
+    @property
+    def iter_label(self) -> IterNodeDepthLevel[tp.Any]:
         raise NotImplementedError() #pragma: no cover
 
     @property

--- a/static_frame/test/typing/test_index.py
+++ b/static_frame/test/typing/test_index.py
@@ -2,6 +2,7 @@ import numpy as np
 import typing_extensions as tp
 
 import static_frame as sf
+from static_frame.core.index_base import IndexBase
 
 TFrameAny = sf.Frame[tp.Any, tp.Any, tp.Unpack[tp.Tuple[tp.Any, ...]]]
 
@@ -59,6 +60,18 @@ def test_index_f() -> None:
 
     idx = sf.Index[np.int64](np.array([4, 1, 0], np.int64))
     x1: np.int64 = idx[1]
+
+
+def test_index_g() -> None:
+
+    def proc(ib:IndexBase) -> int:
+        return len(tuple(ib.iter_label()))
+
+    idx1 = sf.Index[np.int64](np.array([1,2,3], np.int64))
+    idx2 = sf.IndexDate(('2022-01-01', '2023-06-15', '2024-12-31'))
+
+    x1: int = proc(idx1)
+    x2: int = proc(idx2)
 
 
 


### PR DESCRIPTION
Addresses #919

I had a couple of questions since it's my first PR:

- Is it okay to import `IndexBase` in `typing/test_index.py` from the core module? 
- Does the test achieve the desired coverage? (mypy fails upon removal of the code addition to `IndexBase`)

