### PR TITLE
Burkland/doc build task bug

### DIFF
--- a/doc/doc_build.py
+++ b/doc/doc_build.py
@@ -1,1 +1,0 @@
-build_doc.py

--- a/doc/doc_build.py
+++ b/doc/doc_build.py
@@ -1,0 +1,1 @@
+build_doc.py

--- a/tasks.py
+++ b/tasks.py
@@ -22,12 +22,6 @@ def clean(context):
     context.run('rm -rf .ruff_cache')
 
 
-@task()
-def doc(context):
-    """Build docs"""
-    context.run(f'{sys.executable} doc/build_doc.py')
-
-
 @task
 def performance(context):
     """Run performance tests."""

--- a/tasks.py
+++ b/tasks.py
@@ -25,7 +25,7 @@ def clean(context):
 @task()
 def doc(context):
     """Build docs"""
-    context.run(f'{sys.executable} doc/doc_build.py')
+    context.run(f'{sys.executable} doc/build_doc.py')
 
 
 @task


### PR DESCRIPTION
The task `doc`, attempts to execute a file that doesn't exist in the repo. I've updated the task, and added a symlink to the old file. Not sure if that's needed